### PR TITLE
SFLW-38/Change hyperlink colour in cookie consent banner

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -49,7 +49,7 @@ export default class Body extends React.Component {
                     declineButtonText="Decline"
                     font-family = "Segoe UI"
                     cookieName="gatsby-gdpr-google-analytics"
-                    style={{ background: "#394A74" }}
+                    style={{ background: "#7f92c0"}}
                     buttonStyle={{ background: "#FFFFFF", color:"#394A74", fontSize: "1em", borderRadius: '5px', padding: "0.625em 1.5em" }}>
                     We value your privacy. We use cookies to give you the best online experience and to better understand our visitors. To find out more, please read our <Link to="/terms/"> privacy policy</Link>.
                 </CookieConsent>


### PR DESCRIPTION
As there was a previous pull request to change the hyperlink colour to white, but that had created contrast problems with other hyperlinks elsewhere, I modified the color of the banner itself instead to something lighter