### PR TITLE
SFLW-64-create-team-card-template

### DIFF
--- a/src/components/TeamSection.js
+++ b/src/components/TeamSection.js
@@ -34,18 +34,6 @@ export default class TeamSection extends React.Component {
                                         }}
                                     >
                                         <div className="card team-member">
-                                            {person_data.photo && (
-                                                <figure className="card__media card__media--bottom">
-                                                    <img
-                                                        src={withPrefix(
-                                                            person_data.photo
-                                                        )}
-                                                        alt={
-                                                            person_data.photo_alt
-                                                        }
-                                                    />
-                                                </figure>
-                                            )}
                                             <div
                                                 className="card__body"
                                                 style={{
@@ -72,12 +60,31 @@ export default class TeamSection extends React.Component {
                                                     </h4>
                                                 </header>
                                                 {person_data.bio && (
-                                                    <div className="card__copy">
+                                                    <div 
+														className="card__copy"
+														style={{
+                                                            marginBottom: "0px",
+															marginTop: "0px",
+                                                        }}
+													>
                                                         {markdownify(
                                                             person_data.bio
                                                         )}
                                                     </div>
                                                 )}
+												
+												{person_data.photo && (
+													<figure className="card__media card__media--middle">
+														<img
+															src={withPrefix(
+																person_data.photo
+															)}
+															alt={
+																person_data.photo_alt
+															}
+														/>
+													</figure>
+												)}
 
                                                 <div
                                                     class="icon"

--- a/src/sass/components/_cards.scss
+++ b/src/sass/components/_cards.scss
@@ -35,6 +35,14 @@
       border-radius: 3px 3px 0 0;
     }
   }
+  
+  &--middle {
+    margin: 0 0 1em 0;
+
+    img {
+      border-radius: 0 0 3px 3px;
+    }
+  }
 
   &--bottom {
     order: 1;
@@ -53,7 +61,7 @@
 .card__header,
 .card__meta,
 .card__footer {
-  margin-bottom: 1.125rem;
+  margin-bottom: 0.125rem;
 }
 
 .card__title {
@@ -69,7 +77,7 @@
 
 .card__copy {
   & > *:last-child {
-    margin-bottom: 1.125rem;
+    margin-bottom: 0;
   }
 }
 


### PR DESCRIPTION
Changes the team card template to match the newer version in the Figma.

Functionality for displaying someone's job title apparently already existed, but was unused. I just moved a few elements around and messed with margins to make it look better.

To add a member's job title:
-Go to their .yaml file in src/data/team/THEIRTEAM
-add bio: INSERT_JOB_TITLE_HERE (for example, bio: executive president)